### PR TITLE
Ignore flutter internal variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0
+* Fix: ignore flutter-internal variables when creating Environment.xcconfig
+
 ## 0.1.0
 * Fix: handle spaces in project directory paths for iOS setup
 > - Updated setup_env.sh script to correctly handle spaces in directory paths by quoting all path references.

--- a/ios/setup_env.sh
+++ b/ios/setup_env.sh
@@ -54,7 +54,7 @@ for SCHEME_FILE in "$SCHEMES_DIR"/*.xcscheme; do
             print "            ActionType = \"Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction\">"
             print "            <ActionContent"
             print "               title = \"Run Script\""
-            print "               scriptText = \"#!/bin/sh&#10;&#10;function entry_decode() { echo &quot;${*}&quot; | base64 --decode; }&#10;&#10;IFS=&apos;,&apos; read -r -a define_items &lt;&lt;&lt; &quot;$DART_DEFINES&quot;&#10;&#10;for index in &quot;${!define_items[@]}&quot;&#10;do&#10;    define_items[$index]=$(entry_decode &quot;${define_items[$index]}&quot;);&#10;done&#10;&#10;printf &quot;%s\\n&quot; &quot;${define_items[@]}&quot; &gt; ${SRCROOT}/Flutter/Environment.xcconfig&#10;\">"
+            print "               scriptText = \"#!/bin/sh&#10;&#10;function entry_decode() { echo &quot;\${*}&quot; | base64 --decode; }&#10;&#10;IFS=&apos;,&apos; read -r -a define_items &lt;&lt;&lt; &quot;\$DART_DEFINES&quot;&#10;&#10;&gt; \${SRCROOT}/Flutter/Environment.xcconfig&#10;&#10;for index in &quot;\${!define_items[@]}&quot;&#10;do&#10;    decoded_item=\$(entry_decode &quot;\${define_items[\$index]}&quot;)&#10;    if [[ ! &quot;\$decoded_item&quot; == flutter.* ]]; then&#10;        echo &quot;\$decoded_item&quot; &gt;&gt; \${SRCROOT}/Flutter/Environment.xcconfig&#10;    fi&#10;done&#10;\">"
             print "               <EnvironmentBuildable>"
             print "                  <BuildableReference"
             print "                     BuildableIdentifier = \"" buildable_identifier "\""

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_env_native
 description: "A plugin/utility that provides compile-time variables for native platforms."
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/Mastersam07/flutter_env_native
 repository: https://github.com/Mastersam07/flutter_env_native
 issue_tracker: https://github.com/Mastersam07/flutter_env_native/issues


### PR DESCRIPTION
fixes #2 

This PR has one HUGE problem I did not find a solution for:
When you already installed an older version of the plugin, it will not re-add the script on running pod install.
The correct way would be to remove the old script and insert the new one in case it changed in the plugin code.

However, I did not find an easy way to do this.

The "solution" is to remove the old script manually from the xcscheme file.